### PR TITLE
Allow spaces in the file path where the firmware sources are located

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 # Path locations for firmware Loader, firmware image tools, etc
-TOOLSPATH = $(CURDIR)/.bin
+TOOLSPATH = .bin
 HEX2IMAGE = $(TOOLSPATH)/hex2k66img
 SENDMIDI  = $(TOOLSPATH)/sendmidi
 LOADER    = $(TOOLSPATH)/firmwareloader
@@ -15,7 +15,7 @@ DOXYGEN = $(TOOLCHAINPATH)/doxygen/doxygen
 COMPILERPATH = $(TOOLCHAINPATH)/arm/bin
 
 # Location of project scripts
-SCRIPTSPATH = $(CURDIR)/scripts
+SCRIPTSPATH = scripts
 
 
 # The name of your project
@@ -31,10 +31,10 @@ BASEPATH = base
 LIBRARYPATH = lib
 
 # Directory to build in
-BUILDDIR = $(abspath $(CURDIR)/build)
+BUILDDIR = build
 
 # Directory with tests
-TESTDIR = $(abspath $(CURDIR)/tests)
+TESTDIR = tests
 
 # Path where the generated documentation will be stored
 DOCS = docs

--- a/scripts/install-tools
+++ b/scripts/install-tools
@@ -5,22 +5,22 @@
 # Assume we're being invoked from the project root
 TOOLS_DIR=tools
 
-mkdir -p "${BIN_DIR}"
+mkdir -p ${BIN_DIR}
 
 # Build firmwareloader
-FIRMWARELOADER_DIR="${TOOLS_DIR}/firmwareloader"
+FIRMWARELOADER_DIR=${TOOLS_DIR}/firmwareloader
 printf "Installing firmwareloader..." \
-  && make -C "${FIRMWARELOADER_DIR}" >/dev/null \
-  && cp -f "${FIRMWARELOADER_DIR}/build/firmwareloader" "${FIRMWARELOADER}" \
-  && make -C "${FIRMWARELOADER_DIR}" clean \
+  && make -C ${FIRMWARELOADER_DIR} >/dev/null \
+  && cp -f ${FIRMWARELOADER_DIR}/build/firmwareloader ${FIRMWARELOADER} \
+  && make -C ${FIRMWARELOADER_DIR} clean \
   && echo "done."
 
 # Build hex2k66img
-HEX2K66IMG_DIR="${TOOLS_DIR}/hex2k66img"
+HEX2K66IMG_DIR=${TOOLS_DIR}/hex2k66img
 printf "Installing hex2k66img..." \
-  && make -C "${HEX2K66IMG_DIR}" >/dev/null \
-  && cp -f "${HEX2K66IMG_DIR}/build/hex2k66img" "${HEX2K66IMG}" \
-  && make -C "${HEX2K66IMG_DIR}" clean \
+  && make -C ${HEX2K66IMG_DIR} >/dev/null \
+  && cp -f ${HEX2K66IMG_DIR}/build/hex2k66img ${HEX2K66IMG} \
+  && make -C ${HEX2K66IMG_DIR} clean \
   && echo "done."
 
 # Install SendMIDI

--- a/tools/firmwareloader/Makefile
+++ b/tools/firmwareloader/Makefile
@@ -26,29 +26,29 @@ endif
 #USE_LIBUSB ?= YES
 
 TARGET = firmwareloader
-BUILDDIR = $(abspath $(CURDIR)/build)
+BUILDDIR = $(CURDIR)/build
 
 ifeq ($(PLATFORM), LINUX)  # also works on FreeBSD
 CC ?= gcc
 CFLAGS ?= -O2 -Wall
 firmwareloader: firmwareloader.c
-	@$(MKDIR) -p $(BUILDDIR)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -s -DUSE_LIBUSB -o $(BUILDDIR)/$(TARGET) firmwareloader.c -lusb $(LDFLAGS)
+	@$(MKDIR) -p "$(BUILDDIR)"
+	$(CC) $(CFLAGS) $(CPPFLAGS) -s -DUSE_LIBUSB -o "$(BUILDDIR)/$(TARGET)" firmwareloader.c -lusb $(LDFLAGS)
 
 else ifeq ($(PLATFORM), WINDOWS)
 CC = i586-mingw32msvc-gcc
 CFLAGS ?= -O2 -Wall
 firmwareloader.exe: firmwareloader.c
-	@$(MKDIR) -p $(BUILDDIR)
-	$(CC) $(CFLAGS) -s -DUSE_WIN32 -o $(BUILDDIR)/$(TARGET).exe firmwareloader.c -lhid -lsetupapi -lwinmm
+	@$(MKDIR) -p "$(BUILDDIR)"
+	$(CC) $(CFLAGS) -s -DUSE_WIN32 -o "$(BUILDDIR)/$(TARGET).exe" firmwareloader.c -lhid -lsetupapi -lwinmm
 
 else ifeq ($(PLATFORM), DARWIN)
 ifeq ($(USE_LIBUSB), YES)
 CC ?= gcc
 CFLAGS ?= -O2 -Wall -mmacosx-version-min=10.5
 firmwareloader: firmwareloader.c
-	@$(MKDIR) -p $(BUILDDIR)
-	$(CC) $(CFLAGS) -s -DUSE_LIBUSB -DMACOSX -o $(BUILDDIR)/$(TARGET) firmwareloader.c -lusb -I /usr/local/include -L/usr/local/lib
+	@$(MKDIR) -p "$(BUILDDIR)"
+	$(CC) $(CFLAGS) -s -DUSE_LIBUSB -DMACOSX -o "$(BUILDDIR)/$(TARGET)" firmwareloader.c -lusb -I /usr/local/include -L/usr/local/lib
 else
 CC ?= gcc
 SDK ?= $(shell xcrun --show-sdk-path)
@@ -57,19 +57,19 @@ firmwareloader: firmwareloader.c
 ifeq ($(SDK),)
 	$(error SDK was not found. To use this type of compilation please install Xcode)
 endif
-	@$(MKDIR) -p $(BUILDDIR)
-	$(CC) $(CFLAGS) -DUSE_APPLE_IOKIT -isysroot $(SDK) -o $(BUILDDIR)/$(TARGET) firmwareloader.c -Wl,-syslibroot,$(SDK) -framework IOKit -framework CoreFoundation
+	@$(MKDIR) -p "$(BUILDDIR)"
+	$(CC) $(CFLAGS) -DUSE_APPLE_IOKIT -isysroot $(SDK) -o "$(BUILDDIR)/$(TARGET)" firmwareloader.c -Wl,-syslibroot,$(SDK) -framework IOKit -framework CoreFoundation
 endif
 
 else ifeq ($(PLATFORM), BSD)  # works on NetBSD and OpenBSD
 CC ?= gcc
 CFLAGS ?= -O2 -Wall
 firmwareloader: firmwareloader.c
-	@$(MKDIR) -p $(BUILDDIR)
-	$(CC) $(CFLAGS) -s -DUSE_UHID -o $(BUILDDIR)/$(TARGET) firmwareloader.c
+	@$(MKDIR) -p "$(BUILDDIR)"
+	$(CC) $(CFLAGS) -s -DUSE_UHID -o "$(BUILDDIR)/$(TARGET)" firmwareloader.c
 endif
 
 all: firmwareloader
 
 clean:
-	@rm -rf $(BUILDDIR)
+	@rm -rf "$(BUILDDIR)"

--- a/tools/hex2k66img/Makefile
+++ b/tools/hex2k66img/Makefile
@@ -3,13 +3,13 @@ CFLAGS = -Wall -pedantic
 MKDIR = mkdir
 
 TARGET = hex2k66img
-BUILDDIR = $(abspath $(CURDIR)/build)
+BUILDDIR = $(CURDIR)/build
 
 all: $(TARGET)
 
 $(TARGET): $(TARGET).c
-	@$(MKDIR) -p $(BUILDDIR)
-	$(CC) $(CFLAGS) -o $(BUILDDIR)/$(TARGET) $(TARGET).c
+	@$(MKDIR) -p "$(BUILDDIR)"
+	$(CC) $(CFLAGS) -o "$(BUILDDIR)/$(TARGET)" $(TARGET).c
 
 clean:
-	@$(RM) -r $(BUILDDIR)
+	@$(RM) -r "$(BUILDDIR)"


### PR DESCRIPTION
Fixes #1 

The issue was caused by having spaces in the file path, where the firmware sources were.