### PR TITLE
Fix the includes to allow building on linux

### DIFF
--- a/src/Midi/SysexHandlerCtrl.h
+++ b/src/Midi/SysexHandlerCtrl.h
@@ -4,7 +4,7 @@
 #include "Sysex.h"
 #include "LocalFile.h"
 #include "System.h"
-#include "base64.h"
+#include "Base64.h"
 
 enum class FileType { preset, config, luaScript, uiToolkit, unknown };
 

--- a/src/System/RuntimeInfo.h
+++ b/src/System/RuntimeInfo.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <arduino.h>
+#include <Arduino.h>
 
 class RuntimeInfo
 {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,7 +24,7 @@ INCDIRS=-I./ -I./$(STUBSDIR) -I./$(FAKESDIR) -I./$(MOCKSDIR) -I../src
 CXXFLAGS = -Wall -Werror -c $(INCDIRS) -std=c++11
 
 CPPUTEST_HOME = /usr/local/Cellar/cpputest/4.0
-CXXFLAGS += -I$(CPPUTEST_HOME)/include -include "arduino.h"
+CXXFLAGS += -I$(CPPUTEST_HOME)/include -include "Arduino.h"
 
 LDFLAGS = -lCppUTest -lCppUTestExt
 

--- a/tests/fakes/helpers.cpp
+++ b/tests/fakes/helpers.cpp
@@ -5,7 +5,7 @@
 #include <cstdarg>
 #include <cstring>
 #include <iostream>
-#include "arduino.h"
+#include "Arduino.h"
 #include "helpers.h"
 
 using namespace std;

--- a/tests/fakes/helpers.h
+++ b/tests/fakes/helpers.h
@@ -3,7 +3,7 @@
 #include <cstdarg>
 #include <vector>
 #include <cstdint>
-#include "arduino.h"
+#include "Arduino.h"
 
 #define _HELPERS_H
 

--- a/tests/stubs/arduino.cpp
+++ b/tests/stubs/arduino.cpp
@@ -1,4 +1,4 @@
-#include "arduino.h"
+#include "Arduino.h"
 
 void interrupts(void)
 {


### PR DESCRIPTION
This fixes a couple case-sensitive includes to allow builds pass on case-sensitive file systems (e.g. on linux)