### PR TITLE
window manager - activeWindow

### DIFF
--- a/src/Windows/Window.cpp
+++ b/src/Windows/Window.cpp
@@ -93,7 +93,7 @@ Component *Window::getActiveComponent(void)
 
 void Window::paint(Graphics &g)
 {
-    if (isVisible()) {
+    if (isVisible() && contentComponent) {
         contentComponent->paintWithChildren(g);
     }
 }

--- a/src/Windows/WindowManager.cpp
+++ b/src/Windows/WindowManager.cpp
@@ -15,8 +15,18 @@ bool WindowManager::addWindow(Window *windowToAdd)
 
 void WindowManager::removeWindow(Window *windowToRemove)
 {
-    if (windows.back() == windowToRemove) {
-        static_cast<void>(windows.pop_back());
+    uint8_t idx = 0;
+    for(auto i = windows.begin();i != windows.end();i++) {
+        if(*i == windowToRemove) {
+            windows.erase(i);
+            if(activeIdx == idx) {
+                if(activeIdx > 0) {
+                    setActiveIdx(activeIdx - 1);
+                }
+            }
+            // note: iterator is invalid! 
+            return;
+        }
     }
 }
 
@@ -27,17 +37,60 @@ int WindowManager::getNumWindows(void)
 
 Window *WindowManager::getWindow(uint8_t index)
 {
+    if(index >= windows.size()) {
+        return nullptr;
+    }
     return (windows[index]);
 }
 
 Window *WindowManager::getActiveWindow(void)
 {
-    if (windows.size() > 0) {
-        return (windows.back());
-    }
-
-    return (nullptr);
+    return getWindow(activeIdx);   
 }
+
+
+void WindowManager::setActiveWindow(Window *newActiveWindow) {
+    uint8_t idx = 0;
+    for(const auto& i : windows) {
+        if(i == newActiveWindow) {
+            setActiveIdx(idx);
+            return;
+        }
+        idx++;
+    }
+}
+
+void WindowManager::setActiveIdx(uint8_t index) {
+    if(index < windows.size()) {
+        activate(index);
+    }
+}
+
+uint8_t WindowManager::getActiveIdx() {
+    return activeIdx;
+
+}
+
+
+
+void WindowManager::activate(uint8_t idx) {
+    activeIdx = idx;
+
+    // todo? 
+    // do we need to deactivate windows, so that they dont start processing events? 
+
+    // auto oldW = getWindow(activeIdx); 
+    // auto newW = getWindow(idx);
+    // if(oldW) {
+    //     oldW->setActive(false);
+    // }
+
+    // if(newW) {
+    //     newW->setActive(true);
+    // }
+}
+
+
 
 /**
  * Repaints currently active window

--- a/src/Windows/WindowManager.h
+++ b/src/Windows/WindowManager.h
@@ -11,13 +11,21 @@ public:
 
     bool addWindow(Window *windowToAdd);
     void removeWindow(Window *windowToRemove);
+
     Window *getWindow(uint8_t index);
-    Window *getActiveWindow(void);
     int getNumWindows(void);
 
+    Window *getActiveWindow(void);
     void setActiveWindow(Window *newActiveWindow);
+
+    void    setActiveIdx(uint8_t);
+    uint8_t getActiveIdx();
+
     void repaintActive(void);
 
 private:
+    void activate(uint8_t idx);
+
     std::vector<Window *> windows;
+    uint8_t activeIdx = 0;
 };


### PR DESCRIPTION
setActiveWindow was unimplemented.... so this PR provides an implementation.

essentially the WM becomes a 'store' of windows which an application can switch between.
(Ive provided both index and pointer function, since some apps may prefer one of other) 

since the systemtask is called repaintActive, I don't believe we need to make the windows visible.

however, I need to test to see if event processor are checking to see if the window is active or not before dispatching the event.

if not, we may may need to deactivate the old active window... then the window would checked it was active before dispatching to its components.

this deactivation code is in activate() method, but I want to see what current behaviour and check current window behaviour before inserting it - so its commented out.


notes :  
-  activeIdx is uint, which doesn't really allow for 'no active window' , which is the case for when no windows exist... so apps would need to also check getnumwindows for this case - but in practical use, I don't see this being a common use-case
- changing active window does NOT cause a repaint, so app should do this... we could change this, since I cannot think of use-case where when you change the active window you'd not want to repaint.


thoughts? 
